### PR TITLE
Add multi-select quiz flow with gauge scores

### DIFF
--- a/lib/screens/landing_page.dart
+++ b/lib/screens/landing_page.dart
@@ -3,7 +3,8 @@
 import 'package:flutter/material.dart';
 import '../models/question.dart';
 import '../theme/app_theme.dart';
-import 'test_page.dart';
+import 'start_test_page.dart';
+import '../widgets/score_gauge.dart';
 
 class LandingPage extends StatefulWidget {
   const LandingPage({Key? key}) : super(key: key);
@@ -14,7 +15,6 @@ class LandingPage extends StatefulWidget {
 
 class _LandingPageState extends State<LandingPage> {
   final List<String> sports = ['Tenis', 'Futbol', 'Basketbol', 'Go Kart'];
-  String? selectedSport;
   final Map<String, int> scores = {};
 
   // Soru şablonları ve her bir şablonun seçenek/puanları
@@ -76,99 +76,72 @@ class _LandingPageState extends State<LandingPage> {
         text: text,
         options: List<String>.from(tpl['options']),
         scores: List<int>.from(tpl['scores']),
+        isMultiSelect: true,
       );
     }).toList();
+  }
+
+  void _startTest(String sport) async {
+    final result = await Navigator.push<int>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => StartTestPage(
+          sport: sport,
+          questions: _questionsForSport(sport),
+        ),
+      ),
+    );
+    if (result != null) {
+      setState(() {
+        scores[sport] = result;
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = AppTheme.themeData;
-    final hasScore = selectedSport != null && scores.containsKey(selectedSport);
 
     return Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
-      appBar: AppBar(title: const Text('Spor Testi'), centerTitle: true),
-      body: Padding(
+      appBar: AppBar(title: const Text('Spor Seç'), centerTitle: true),
+      body: ListView(
         padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Spor seçimi dropdown
-            DropdownButtonFormField<String>(
-              decoration: const InputDecoration(
-                labelText: 'Spor Seç',
-                floatingLabelStyle: TextStyle(color: Colors.white70),
-                enabledBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Colors.white54),
-                ),
-              ),
-              dropdownColor: theme.primaryColor,
-              style: const TextStyle(color: Colors.white),
-              value: selectedSport,
-              items:
-                  sports
-                      .map((s) => DropdownMenuItem(value: s, child: Text(s)))
-                      .toList(),
-              onChanged: (v) {
-                setState(() {
-                  selectedSport = v;
-                });
-              },
+        children: sports.map((sport) {
+          final hasScore = scores.containsKey(sport);
+          return Container(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+            decoration: BoxDecoration(
+              color: Colors.white10,
+              borderRadius: BorderRadius.circular(16),
             ),
-            const SizedBox(height: 32),
-
-            if (selectedSport == null)
-              Text(
-                'Lütfen önce bir spor seç.',
-                style: theme.textTheme.bodyMedium,
-                textAlign: TextAlign.center,
-              )
-            else if (hasScore)
-              Column(
-                children: [
-                  Text(
-                    '$selectedSport Test Skorun:',
-                    style: theme.textTheme.titleLarge?.copyWith(fontSize: 20),
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    '${scores[selectedSport]}/10',
-                    style: theme.textTheme.titleLarge?.copyWith(fontSize: 36),
-                  ),
-                ],
-              )
-            else
-              ElevatedButton(
-                onPressed: () async {
-                  final result = await Navigator.push<int>(
-                    context,
-                    MaterialPageRoute(
-                      builder:
-                          (_) => TestPage(
-                            questions: _questionsForSport(selectedSport!),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(sport, style: theme.textTheme.titleMedium),
+                hasScore
+                    ? ScoreGauge(score: scores[sport]!)
+                    : ElevatedButton(
+                        onPressed: () => _startTest(sport),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: theme.primaryColor,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 12,
                           ),
-                    ),
-                  );
-                  if (result != null) {
-                    setState(() {
-                      scores[selectedSport!] = result;
-                    });
-                  }
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: theme.primaryColor,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: const StadiumBorder(),
-                ),
-                child: Text(
-                  'Teste Başla',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    color: Colors.white,
-                  ),
-                ),
-              ),
-          ],
-        ),
+                          shape: const StadiumBorder(),
+                        ),
+                        child: Text(
+                          'Teste Başla',
+                          style: theme.textTheme.bodyMedium
+                              ?.copyWith(color: Colors.white),
+                        ),
+                      ),
+              ],
+            ),
+          );
+        }).toList(),
       ),
     );
   }

--- a/lib/screens/start_test_page.dart
+++ b/lib/screens/start_test_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../models/question.dart';
+import '../theme/app_theme.dart';
+import 'test_page.dart';
+
+class StartTestPage extends StatelessWidget {
+  final String sport;
+  final List<Question> questions;
+  const StartTestPage({Key? key, required this.sport, required this.questions}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppTheme.themeData;
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      appBar: AppBar(title: Text(sport), centerTitle: true),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          const Spacer(),
+          Text(
+            'Seviyeni\nHemen Ölç!',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleLarge?.copyWith(fontSize: 28),
+          ),
+          const Spacer(),
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                ElevatedButton(
+                  onPressed: () async {
+                    final result = await Navigator.push<int>(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TestPage(questions: questions),
+                      ),
+                    );
+                    Navigator.pop(context, result);
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: theme.primaryColor,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: const StadiumBorder(),
+                  ),
+                  child: Text(
+                    'Hemen Başla',
+                    style: theme.textTheme.titleMedium?.copyWith(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  style: TextButton.styleFrom(foregroundColor: Colors.white),
+                  child: const Text('Daha Sonra'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/score_gauge.dart
+++ b/lib/widgets/score_gauge.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import '../theme/app_theme.dart';
+
+class ScoreGauge extends StatelessWidget {
+  final int score;
+  const ScoreGauge({Key? key, required this.score}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppTheme.themeData;
+    const double width = 80;
+    final double position = (score.clamp(0, 10) / 10) * width;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: width,
+          height: 20,
+          child: Stack(
+            children: [
+              Container(
+                width: width,
+                height: 6,
+                decoration: BoxDecoration(
+                  color: Colors.white24,
+                  borderRadius: BorderRadius.circular(3),
+                ),
+              ),
+              Positioned(
+                left: position - 6,
+                top: 0,
+                child: Icon(
+                  Icons.navigation,
+                  color: theme.primaryColor,
+                  size: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '$score/10',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add gauge widget to display results
- add StartTestPage with prompt before starting test
- update LandingPage to list sports and show gauge or start button
- allow multi-selection of answers in TestPage

## Testing
- `dart format lib/screens/landing_page.dart lib/screens/start_test_page.dart lib/screens/test_page.dart lib/widgets/score_gauge.dart` *(fails: `dart` not found)*
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653dee16848327838a0e0b3e8c2bf1