### PR TITLE
Correct scoring calculation and show decimal results

### DIFF
--- a/lib/screens/start_test_page.dart
+++ b/lib/screens/start_test_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../models/question.dart';
+import '../theme/app_theme.dart';
+import 'test_page.dart';
+
+class StartTestPage extends StatelessWidget {
+  final String sport;
+  final List<Question> questions;
+  const StartTestPage({Key? key, required this.sport, required this.questions}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppTheme.themeData;
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      appBar: AppBar(title: Text(sport), centerTitle: true),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          const Spacer(),
+          Text(
+            'Seviyeni\nHemen Ölç!',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleLarge?.copyWith(fontSize: 28),
+          ),
+          const Spacer(),
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                ElevatedButton(
+                  onPressed: () async {
+                    final result = await Navigator.push<double>(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TestPage(questions: questions),
+                      ),
+                    );
+                    Navigator.pop(context, result);
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: theme.primaryColor,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: const StadiumBorder(),
+                  ),
+                  child: Text(
+                    'Hemen Başla',
+                    style: theme.textTheme.titleMedium?.copyWith(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  style: TextButton.styleFrom(foregroundColor: Colors.white),
+                  child: const Text('Daha Sonra'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/score_gauge.dart
+++ b/lib/widgets/score_gauge.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import '../theme/app_theme.dart';
+
+class ScoreGauge extends StatelessWidget {
+  final double score;
+  const ScoreGauge({Key? key, required this.score}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppTheme.themeData;
+    const double width = 80;
+    final double position = (score.clamp(0.0, 10.0) / 10) * width;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: width,
+          height: 20,
+          child: Stack(
+            children: [
+              Container(
+                width: width,
+                height: 6,
+                decoration: BoxDecoration(
+                  color: Colors.white24,
+                  borderRadius: BorderRadius.circular(3),
+                ),
+              ),
+              Positioned(
+                left: position - 6,
+                top: 0,
+                child: Icon(
+                  Icons.navigation,
+                  color: theme.primaryColor,
+                  size: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '${score.toStringAsFixed(1)}/10',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- adjust scoring to average selected answers so max score equals 10
- store decimal scores and update gauge widget
- pass score as `double` between pages
- make gender and age questions single-choice

## Testing
- `dart format lib/screens/landing_page.dart lib/screens/start_test_page.dart lib/screens/test_page.dart lib/widgets/score_gauge.dart` *(fails: `dart` not found)*
- `flutter analyze` *(fails: `flutter` not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68653dee16848327838a0e0b3e8c2bf1